### PR TITLE
Set default matchmaking strategy and default rating system

### DIFF
--- a/action.php
+++ b/action.php
@@ -41,6 +41,13 @@ function assign_question_list(capquiz $capquiz) {
     }
 }
 
+function validate_matchmaking_and_rating_systems(capquiz $capquiz) {
+    if (!$capquiz->rating_system_loader()->has_rating_system())
+        $capquiz->rating_system_loader()->set_default_rating_system();
+    if (!$capquiz->selection_strategy_loader()->has_strategy())
+        $capquiz->selection_strategy_loader()->set_default_strategy();
+}
+
 function create_capquiz_question(int $question_id, capquiz_question_list $list, float $rating) {
     global $DB;
     $rated_question = new \stdClass();
@@ -59,7 +66,7 @@ function remove_capquiz_question(int $question_id, int $question_list_id) {
 function add_question_to_list(capquiz $capquiz) {
     $question_list = $capquiz->question_list();
     if ($question_id = optional_param(capquiz_urls::$param_question_id, 0, PARAM_INT)) {
-           create_capquiz_question($question_id, $question_list, $question_list->default_question_rating());
+        create_capquiz_question($question_id, $question_list, $question_list->default_question_rating());
     }
     redirect_to_previous();
 }
@@ -115,6 +122,7 @@ function determine_action(capquiz $capquiz, string $action_type) {
         redirect_to($capquiz);
     } else if ($action_type == capquiz_actions::$set_question_list) {
         assign_question_list($capquiz);
+        validate_matchmaking_and_rating_systems($capquiz);
     } else if ($action_type == capquiz_actions::$add_question_to_list) {
         add_question_to_list($capquiz);
     } else if ($action_type == capquiz_actions::$remove_question_from_list) {

--- a/action.php
+++ b/action.php
@@ -41,13 +41,6 @@ function assign_question_list(capquiz $capquiz) {
     }
 }
 
-function validate_matchmaking_and_rating_systems(capquiz $capquiz) {
-    if (!$capquiz->rating_system_loader()->has_rating_system())
-        $capquiz->rating_system_loader()->set_default_rating_system();
-    if (!$capquiz->selection_strategy_loader()->has_strategy())
-        $capquiz->selection_strategy_loader()->set_default_strategy();
-}
-
 function create_capquiz_question(int $question_id, capquiz_question_list $list, float $rating) {
     global $DB;
     $rated_question = new \stdClass();
@@ -122,7 +115,6 @@ function determine_action(capquiz $capquiz, string $action_type) {
         redirect_to($capquiz);
     } else if ($action_type == capquiz_actions::$set_question_list) {
         assign_question_list($capquiz);
-        validate_matchmaking_and_rating_systems($capquiz);
     } else if ($action_type == capquiz_actions::$add_question_to_list) {
         add_question_to_list($capquiz);
     } else if ($action_type == capquiz_actions::$remove_question_from_list) {

--- a/classes/capquiz.php
+++ b/classes/capquiz.php
@@ -112,6 +112,7 @@ class capquiz {
 
     public function assign_question_list(int $question_list_id) {
         global $DB;
+        $this->validate_matchmaking_and_rating_systems();
         $question_list = capquiz_question_list::load_any($this, $question_list_id);
         if (!$question_list) {
             return false;
@@ -254,5 +255,12 @@ class capquiz {
         $question_usage->set_preferred_behaviour('immediatefeedback');
         \question_engine::save_questions_usage_by_activity($question_usage);
         return $question_usage->get_id();
+    }
+
+    private function validate_matchmaking_and_rating_systems() {
+        if (!$this->rating_system_loader()->has_rating_system())
+            $this->rating_system_loader()->set_default_rating_system();
+        if (!$this->selection_strategy_loader()->has_strategy())
+            $this->selection_strategy_loader()->set_default_strategy();
     }
 }

--- a/classes/capquiz_matchmaking_strategy_loader.php
+++ b/classes/capquiz_matchmaking_strategy_loader.php
@@ -90,6 +90,10 @@ class capquiz_matchmaking_strategy_loader {
         }
     }
 
+    public function set_default_strategy() {
+        $this->set_strategy($this->registry->default_selection_strategy());
+    }
+
     public function set_strategy(string $strategy) {
         $selector = $this->registry->selector($strategy);
         $db_entry = new \stdClass;

--- a/classes/capquiz_rating_system_loader.php
+++ b/classes/capquiz_rating_system_loader.php
@@ -88,6 +88,10 @@ class capquiz_rating_system_loader {
         }
     }
 
+    public function set_default_rating_system() {
+        $this->set_rating_system($this->registry->default_rating_system());
+    }
+
     public function set_rating_system(string $rating_system) {
         $system = $this->registry->rating_system($rating_system);
         $db_entry = new \stdClass;

--- a/classes/matchmaking/capquiz_matchmaking_strategy_registry.php
+++ b/classes/matchmaking/capquiz_matchmaking_strategy_registry.php
@@ -62,6 +62,11 @@ class capquiz_matchmaking_strategy_registry {
         return false;
     }
 
+    public function default_selection_strategy(){
+        //default selection strategy is added first. Modify caquiz_matchmaking_strategy_registry:register_selection_strategies() to change this
+        return reset($this->selection_strategies());
+    }
+
     public function selection_strategies() {
         $names = [];
         foreach (array_keys($this->strategies) as $value) {

--- a/classes/output/matchmaking_configuration_renderer.php
+++ b/classes/output/matchmaking_configuration_renderer.php
@@ -45,7 +45,7 @@ class matchmaking_configuration_renderer {
         if ($this->registry->has_strategy()) {
             return $this->render_configuration();
         } else {
-            return '<h3>' . get_string('no_matchmaing_strategy_selected', 'capquiz') . '</h3>';
+            return '<h3>' . get_string('no_matchmaking_strategy_selected', 'capquiz') . '</h3>';
         }
     }
 

--- a/classes/output/renderer.php
+++ b/classes/output/renderer.php
@@ -124,18 +124,6 @@ class renderer extends \plugin_renderer_base {
         $this->display_view(new question_list_selection_renderer($capquiz, $this));
     }
 
-    public function display_set_selection_strategy_view(capquiz $capquiz) {
-        $view = new matchmaking_strategy_selection_renderer($capquiz, $this);
-        $view->set_redirect_url(capquiz_urls::view_url());
-        $this->display_view($view);
-    }
-
-    public function display_set_rating_system_view(capquiz $capquiz) {
-        $view = new rating_system_selection_renderer($capquiz, $this);
-        $view->set_redirect_url(capquiz_urls::view_url());
-        $this->display_view($view);
-    }
-
     public function display_unauthorized_view() {
         $this->display_view(new unauthorized_view_renderer($this));
     }

--- a/classes/rating_system/capquiz_rating_system_registry.php
+++ b/classes/rating_system/capquiz_rating_system_registry.php
@@ -59,6 +59,11 @@ class capquiz_rating_system_registry {
         return false;
     }
 
+    public function default_rating_system(){
+        //default rating system is added first. Modify caquiz_rating_system_regsistry::register_rating_systems() to change this
+        return reset($this->rating_systems());
+    }
+
     public function rating_systems() {
         $names = [];
         foreach (array_keys($this->systems) as $value) {

--- a/lib.php
+++ b/lib.php
@@ -25,12 +25,6 @@ defined('MOODLE_INTERNAL') || die();
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-function capquiz($capquiz) {
-    global $DB;
-    $capquiz->id = $DB->insert_record('capquiz', $capquiz);
-    return $capquiz->id;
-}
-
 function capquiz_add_instance(stdClass $capquiz_mod_form_data) {
     global $DB;
     $capquiz_mod_form_data->time_modified = time();
@@ -38,7 +32,8 @@ function capquiz_add_instance(stdClass $capquiz_mod_form_data) {
     $capquiz_mod_form_data->published = false;
     $capquiz_mod_form_data->question_list_id = null;
     $capquiz_mod_form_data->question_usage_id = null;
-    return $DB->insert_record('capquiz', $capquiz_mod_form_data);
+    $capquiz_id = $DB->insert_record('capquiz', $capquiz_mod_form_data);
+    return $capquiz_id;
 }
 
 function capquiz_update_instance(stdClass $capquiz) {

--- a/version.php
+++ b/version.php
@@ -23,7 +23,7 @@ defined('MOODLE_INTERNAL') || die();
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-$plugin->version = 2018090301 ;
+$plugin->version = 2018091301;
 $plugin->requires = 2016120500 ;
 $plugin->cron = 0;
 $plugin->component = 'mod_capquiz';

--- a/view.php
+++ b/view.php
@@ -41,10 +41,6 @@ $renderer = $capquiz->renderer();
 if ($capquiz->is_instructor()) {
     if (!$capquiz->has_question_list()) {
         $renderer->display_choose_question_list_view($capquiz);
-    } else if (!$capquiz->selection_strategy_loader()->has_strategy()) {
-        $renderer->display_set_selection_strategy_view($capquiz);
-    } else if (!$capquiz->rating_system_loader()->has_rating_system()) {
-        $renderer->display_set_rating_system_view($capquiz);
     } else {
         $renderer->display_instructor_dashboard($capquiz);
     }


### PR DESCRIPTION
Set default matchmaking strategy and default rating system when assigning question list to capquiz if no matchmaking strategy or rating system is specified.

Default matchmaking strategy and rating system is implicitly specified as being the first in the list of available strategies and systems.

Remove unused function capquiz() in lib.php.

Remove unused rendering functions in renderer as a result of refactoring.

Solves #71