### PR TITLE
Store question usages per student instead of question list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+**Warning**  Upgrade from previous version can be exceptionally slow
+if there are activities with a large number of attempts.
+
+### Fixed
+
+- Performance improvements.  Fixes #167
+
 ## [0.5.0] - 2020-09-16
 ### Removed
 - Commenting system for student feedback is removed in favour of the [QTracker plugin](https://github.com/KQMATH/moodle-local_qtracker).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 ## [Unreleased]
 
 **Warning**  Upgrade from previous version can be exceptionally slow
-if there are activities with a large number of attempts.
+if there are activities with a large number of attempts.  The timeout
+limits are reached in PHP, data may be lost.
 
 ### Fixed
 

--- a/async.php
+++ b/async.php
@@ -40,11 +40,11 @@ capquiz_urls::set_page_url($capquiz, capquiz_urls::$urlasync);
 
 if ($attemptid !== null) {
     $user = $capquiz->user();
-    $attempt = capquiz_question_attempt::load_attempt($capquiz, $user, $attemptid);
+    $attempt = capquiz_question_attempt::load_attempt($user, $attemptid);
     if ($action === 'answered') {
-        $capquiz->question_engine()->attempt_answered($user, $attempt);
+        $capquiz->question_engine($user)->attempt_answered($user, $attempt);
     } else if ($action === 'reviewed') {
-        $capquiz->question_engine()->attempt_reviewed($attempt);
+        $capquiz->question_engine($user)->attempt_reviewed($attempt);
     }
     capquiz_urls::redirect_to_dashboard();
 }

--- a/backup/moodle2/backup_capquiz_stepslib.php
+++ b/backup/moodle2/backup_capquiz_stepslib.php
@@ -26,10 +26,9 @@ class backup_capquiz_activity_structure_step extends backup_questions_activity_s
             'name', 'intro', 'introformat', 'timecreated', 'timemodified', 'published', 'default_user_rating'
         ]);
         $questionlist = new backup_nested_element('questionlist', null, [
-            'id', 'capquiz_id', 'question_usage_id', 'title', 'author', 'description',
+            'id', 'capquiz_id', 'title', 'author', 'description',
             'star_ratings', 'is_template', 'time_created', 'time_modified', 'default_question_rating'
         ]);
-        $this->add_question_usages($questionlist, 'question_usage_id');
         $questions = new backup_nested_element('questions');
         $question = new backup_nested_element('question', ['id'], [
             'question_id', 'question_list_id', 'rating'
@@ -48,8 +47,10 @@ class backup_capquiz_activity_structure_step extends backup_questions_activity_s
         ]);
         $users = new backup_nested_element('users');
         $user = new backup_nested_element('user', ['id'], [
-            'user_id', 'capquiz_id', 'rating', 'highest_level'
+            'user_id', 'capquiz_id', 'question_usage_id', 'rating', 'highest_level'
         ]);
+        $this->add_question_usages($user, 'question_usage_id');
+
         $userratings = new backup_nested_element('userratings');
         $userrating = new backup_nested_element('user_rating', ['id'], [
             'capquiz_user_id', 'rating', 'manual', 'timecreated'

--- a/classes/capquiz.php
+++ b/classes/capquiz.php
@@ -113,7 +113,6 @@ class capquiz {
         if (!$this->can_publish()) {
             return false;
         }
-        $this->question_list()->create_question_usage($this->context());
         $this->record->published = true;
         $DB->update_record('capquiz', $this->record);
         return $this->is_published();
@@ -126,8 +125,8 @@ class capquiz {
         return $this->question_list()->has_questions();
     }
 
-    public function question_engine() {
-        $quba = $this->question_usage();
+    public function question_engine(capquiz_user $user) {
+        $quba = $user->question_usage();
         if (!$quba) {
             return null;
         }
@@ -136,16 +135,9 @@ class capquiz {
         return new capquiz_question_engine($this, $quba, $strategyloader, $ratingsystemloader);
     }
 
-    public function question_usage() {
-        if ($this->has_question_list() && $this->is_published()) {
-            return $this->question_list()->question_usage();
-        }
-        return null;
-    }
-
     public function user() : capquiz_user {
         global $USER;
-        return capquiz_user::load_user($this, $USER->id);
+        return capquiz_user::load_user($this, $USER->id, $this->context());
     }
 
     public function default_user_rating() : float {

--- a/classes/capquiz_question_engine.php
+++ b/classes/capquiz_question_engine.php
@@ -48,7 +48,7 @@ class capquiz_question_engine {
     }
 
     public function user_is_completed(capquiz_user $user) : bool {
-        if (capquiz_question_attempt::active_attempt($this->capquiz, $user)) {
+        if (capquiz_question_attempt::active_attempt($user)) {
             return false;
         }
         if ($this->find_question_for_user($user)) {
@@ -58,7 +58,7 @@ class capquiz_question_engine {
     }
 
     public function attempt_for_user(capquiz_user $user) {
-        if ($attempt = capquiz_question_attempt::active_attempt($this->capquiz, $user)) {
+        if ($attempt = capquiz_question_attempt::active_attempt($user)) {
             return $attempt;
         }
         return $this->new_attempt_for_user($user);
@@ -91,7 +91,7 @@ class capquiz_question_engine {
             $ratingsystem->update_user_rating($user, $question, 0);
         }
         $attempt->set_user_rating($user->get_capquiz_user_rating());
-        $previousattempt = capquiz_question_attempt::previous_attempt($this->capquiz, $user);
+        $previousattempt = capquiz_question_attempt::previous_attempt($user);
         if ($previousattempt) {
             $this->update_question_rating($previousattempt, $attempt);
         }
@@ -114,13 +114,13 @@ class capquiz_question_engine {
 
     private function new_attempt_for_user(capquiz_user $user) {
         $question = $this->find_question_for_user($user);
-        return $question ? capquiz_question_attempt::create_attempt($this->capquiz, $user, $question) : null;
+        return $question ? capquiz_question_attempt::create_attempt($user, $question) : null;
     }
 
     private function find_question_for_user(capquiz_user $user) {
         $selector = $this->matchmakingloader->selector();
         $questionlist = $this->capquiz->question_list();
-        $inactiveattempts = capquiz_question_attempt::inactive_attempts($this->capquiz, $user);
+        $inactiveattempts = capquiz_question_attempt::inactive_attempts($user);
         return $selector->next_question_for_user($user, $questionlist, $inactiveattempts);
     }
 

--- a/classes/capquiz_user.php
+++ b/classes/capquiz_user.php
@@ -36,12 +36,15 @@ class capquiz_user {
     /** @var capquiz_user_rating $rating */
     private $rating;
 
+    /** @var \question_usage_by_activity $quba */
+    private $quba;
+
     /**
      * capquiz_user constructor.
      * @param \stdClass $record
      * @throws \dml_exception
      */
-    public function __construct(\stdClass $record) {
+    public function __construct(\stdClass $record, \context_module $context) {
         global $DB;
         $this->record = $record;
         $this->user = $DB->get_record('user', ['id' => $this->record->user_id]);
@@ -52,6 +55,39 @@ class capquiz_user {
         } else {
             $this->rating = $rating;
         }
+        $this->create_question_usage($context);
+        $this->quba = \question_engine::load_questions_usage_by_activity($this->record->question_usage_id);
+    }
+
+    private function has_question_usage() : bool {
+        return $this->record->question_usage_id !== null;
+    }
+
+    public function create_question_usage($context) {
+        global $DB;
+        if ($this->has_question_usage()) {
+            return;
+        }
+        $quba = \question_engine::make_questions_usage_by_activity('mod_capquiz', $context);
+        $quba->set_preferred_behaviour('immediatefeedback');
+        // TODO: Don't suppress the error if it becomes possible to save QUBAs without slots.
+        @\question_engine::save_questions_usage_by_activity($quba);
+        $this->record->question_usage_id = $quba->get_id();
+        $DB->update_record('capquiz_user', $this->record);
+    }
+
+    public function question_usage() {
+        return $this->quba;
+    }
+
+    public function question_engine() {
+        $quba = $this->question_usage();
+        if (!$quba) {
+            return null;
+        }
+        $ratingsystemloader = new capquiz_rating_system_loader($this);
+        $strategyloader = new capquiz_matchmaking_strategy_loader($this);
+        return new capquiz_question_engine($this, $quba, $strategyloader, $ratingsystemloader);
     }
 
     /**
@@ -60,9 +96,9 @@ class capquiz_user {
      * @return capquiz_user|null
      * @throws \Exception
      */
-    public static function load_user(capquiz $capquiz, int $moodleuserid) {
+    public static function load_user(capquiz $capquiz, int $moodleuserid, \context_module $context) {
         global $DB;
-        if ($user = self::load_db_entry($capquiz, $moodleuserid)) {
+        if ($user = self::load_db_entry($capquiz, $moodleuserid, $context)) {
             return $user;
         }
         $record = new \stdClass();
@@ -71,7 +107,7 @@ class capquiz_user {
         $record->rating = $capquiz->default_user_rating();
         $capquizuserid = $DB->insert_record('capquiz_user', $record, true);
         capquiz_user_rating::insert_user_rating_entry($capquizuserid, $record->rating);
-        return self::load_db_entry($capquiz, $moodleuserid);
+        return self::load_db_entry($capquiz, $moodleuserid, $context);
     }
 
     public static function user_count(int $capquizid) : int {
@@ -84,11 +120,11 @@ class capquiz_user {
      * @return capquiz_user[]
      * @throws \dml_exception
      */
-    public static function list_users(int $capquizid) : array {
+    public static function list_users(int $capquizid, \context_module $context) : array {
         global $DB;
         $users = [];
         foreach ($DB->get_records('capquiz_user', ['capquiz_id' => $capquizid]) as $user) {
-            $users[] = new capquiz_user($user);
+            $users[] = new capquiz_user($user, $context);
         }
         return $users;
     }
@@ -146,13 +182,13 @@ class capquiz_user {
      * @return capquiz_user|null
      * @throws \dml_exception
      */
-    private static function load_db_entry(capquiz $capquiz, int $moodleuserid) {
+    private static function load_db_entry(capquiz $capquiz, int $moodleuserid, \context_module $context) {
         global $DB;
         $entry = $entry = $DB->get_record('capquiz_user', [
             'user_id' => $moodleuserid,
             'capquiz_id' => $capquiz->id()
         ]);
-        return $entry ? new capquiz_user($entry) : null;
+        return $entry ? new capquiz_user($entry, $context) : null;
     }
 
 

--- a/classes/capquiz_user.php
+++ b/classes/capquiz_user.php
@@ -80,16 +80,6 @@ class capquiz_user {
         return $this->quba;
     }
 
-    public function question_engine() {
-        $quba = $this->question_usage();
-        if (!$quba) {
-            return null;
-        }
-        $ratingsystemloader = new capquiz_rating_system_loader($this);
-        $strategyloader = new capquiz_matchmaking_strategy_loader($this);
-        return new capquiz_question_engine($this, $quba, $strategyloader, $ratingsystemloader);
-    }
-
     /**
      * @param capquiz $capquiz
      * @param int $moodleuserid

--- a/classes/capquiz_user.php
+++ b/classes/capquiz_user.php
@@ -56,7 +56,11 @@ class capquiz_user {
             $this->rating = $rating;
         }
         $this->create_question_usage($context);
-        $this->quba = \question_engine::load_questions_usage_by_activity($this->record->question_usage_id);
+        try {
+            $this->quba = \question_engine::load_questions_usage_by_activity($this->record->question_usage_id);
+        } catch (\coding_exception $e) {
+            $this->quba = null;
+        }
     }
 
     private function has_question_usage() : bool {
@@ -76,7 +80,7 @@ class capquiz_user {
         $DB->update_record('capquiz_user', $this->record);
     }
 
-    public function question_usage() {
+    public function question_usage() : ?\question_usage_by_activity {
         return $this->quba;
     }
 

--- a/classes/output/classlist_renderer.php
+++ b/classes/output/classlist_renderer.php
@@ -48,7 +48,7 @@ class classlist_renderer {
         global $PAGE;
         $cmid = $this->capquiz->course_module()->id;
         $PAGE->requires->js_call_amd('mod_capquiz/edit_questions', 'initialize', [$cmid]);
-        $users = capquiz_user::list_users($this->capquiz->id());
+        $users = capquiz_user::list_users($this->capquiz->id(), $this->capquiz->context());
         $rows = [];
         for ($i = 0; $i < count($users); $i++) {
             $user = $users[$i];

--- a/classes/output/question_attempt_renderer.php
+++ b/classes/output/question_attempt_renderer.php
@@ -46,13 +46,14 @@ class question_attempt_renderer {
     }
 
     private function render_question_head_html() {
-        $qengine = $this->capquiz->question_engine();
+		$user = $this->capquiz->user();
+        $qengine = $this->capquiz->question_engine($user);
         if ($qengine === null) {
             return;
         }
-        $attempt = $qengine->attempt_for_user($this->capquiz->user());
+        $attempt = $qengine->attempt_for_user($user);
         if ($attempt !== null) {
-            $this->capquiz->question_usage()->render_question_head_html($attempt->question_slot());
+            $user->question_usage()->render_question_head_html($attempt->question_slot());
         }
     }
 
@@ -62,8 +63,9 @@ class question_attempt_renderer {
             return get_string('nothing_here_yet', 'capquiz');
         }
         $PAGE->requires->js_call_amd('mod_capquiz/attempt', 'initialize', []);
-        $qengine = $this->capquiz->question_engine();
-        $attempt = $qengine->attempt_for_user($this->capquiz->user());
+		$user = $this->capquiz->user();
+        $qengine = $this->capquiz->question_engine($user);
+        $attempt = $qengine->attempt_for_user($user);
         if ($attempt) {
             if ($attempt->is_answered()) {
                 return $this->render_review($attempt);
@@ -116,7 +118,8 @@ class question_attempt_renderer {
 
     public function render_question_attempt(capquiz_question_attempt $attempt, \question_display_options $options) : string {
         global $PAGE;
-        $quba = $this->capquiz->question_usage();
+		$user = $this->capquiz->user();
+        $quba = $user->question_usage();
         $PAGE->requires->js_module('core_question_engine');
         return $this->renderer->render_from_template('capquiz/student_question_attempt', [
             'attempt' => [
@@ -125,8 +128,8 @@ class question_attempt_renderer {
                 'slots' => ''
             ],
             'gradingdone' => $this->capquiz->is_grading_completed(),
-            'finalgrade' => $this->capquiz->user()->highest_stars_graded(),
-            'gradingpass' => $this->capquiz->user()->highest_stars_graded() >= $this->capquiz->stars_to_pass(),
+            'finalgrade' => $user->highest_stars_graded(),
+            'gradingpass' => $user->highest_stars_graded() >= $this->capquiz->stars_to_pass(),
             'duedate' => userdate($this->capquiz->time_due(), get_string('strftimedatetime', 'langconfig'))
         ]);
     }

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -166,7 +166,7 @@ class provider implements
                        ca.time_reviewed      AS timereviewed,
                        ca.time_answered      AS timeanswered,
                        cu.id                 AS capuserid,
-                       cql.question_usage_id AS qubaid
+                       cu.question_usage_id  AS qubaid
                   FROM {context} cx
                   JOIN {course_modules} cm
                     ON cm.id = cx.instanceid

--- a/db/install.xml
+++ b/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="mod/capquiz/db" VERSION="20190116" COMMENT="XMLDB file for Moodle module mod/capquiz"
+<XMLDB PATH="mod/capquiz/db" VERSION="20210205" COMMENT="XMLDB file for Moodle module mod/capquiz"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd"
 >
@@ -23,11 +23,10 @@
         <KEY NAME="course" TYPE="foreign" FIELDS="course" REFTABLE="course" REFFIELDS="id"/>
       </KEYS>
     </TABLE>
-    <TABLE NAME="capquiz_question_list" COMMENT="An ordered list of questions used by a CapQuiz assignment.">
+    <TABLE NAME="capquiz_question_list" COMMENT="An ordered list of questions used by a CAPQuiz assignment.">
       <FIELDS>
         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
         <FIELD NAME="capquiz_id" TYPE="int" LENGTH="11" NOTNULL="false" SEQUENCE="false"/>
-        <FIELD NAME="question_usage_id" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="title" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false" COMMENT="Title of this question list"/>
         <FIELD NAME="author" TYPE="int" LENGTH="11" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="description" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false" COMMENT="Short description of the question list"/>
@@ -41,7 +40,6 @@
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
         <KEY NAME="capquiz_id" TYPE="foreign-unique" FIELDS="capquiz_id" REFTABLE="capquiz" REFFIELDS="id"/>
-        <KEY NAME="question_usage_id" TYPE="foreign-unique" FIELDS="question_usage_id" REFTABLE="question_usages" REFFIELDS="id"/>
         <KEY NAME="author" TYPE="foreign" FIELDS="author" REFTABLE="user" REFFIELDS="id"/>
         <KEY NAME="context_id" TYPE="foreign" FIELDS="context_id" REFTABLE="context" REFFIELDS="id"/>
       </KEYS>
@@ -64,6 +62,7 @@
         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
         <FIELD NAME="user_id" TYPE="int" LENGTH="11" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="capquiz_id" TYPE="int" LENGTH="11" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="question_usage_id" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="rating" TYPE="float" LENGTH="11" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="The rating of the specified user for the specified CAPQuiz question list"/>
         <FIELD NAME="highest_level" TYPE="int" LENGTH="11" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="The highest number of stars attained by this user"/>
         <FIELD NAME="stars_graded" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Number of stars for the final grade"/>
@@ -72,6 +71,7 @@
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
         <KEY NAME="user_id" TYPE="foreign" FIELDS="user_id" REFTABLE="user" REFFIELDS="id"/>
         <KEY NAME="capquiz_id" TYPE="foreign" FIELDS="capquiz_id" REFTABLE="capquiz" REFFIELDS="id"/>
+        <KEY NAME="question_usage_id" TYPE="foreign-unique" FIELDS="question_usage_id" REFTABLE="question_usages" REFFIELDS="id"/>
       </KEYS>
     </TABLE>
     <TABLE NAME="capquiz_attempt" COMMENT="Attempt table">

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -23,7 +23,7 @@ defined('MOODLE_INTERNAL') || die();
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 function xmldb_capquiz_upgrade($oldversion) {
-    global $DB;
+    global $DB, $OUTPUT;
     $dbman = $DB->get_manager();
     if ($oldversion < 2019060705) {
         $table = new xmldb_table('capquiz_attempt');
@@ -246,6 +246,10 @@ function xmldb_capquiz_upgrade($oldversion) {
 				continue;
 			}
 			$oldquba = $DB->get_record('question_usages', ['id' => $oldqubaid]);
+			if (!$oldquba) {
+				echo $OUTPUT->notification("Did not find question usage with id $oldqubaid for question list {$qlist->title} ({$qlist->id})");
+				continue;
+			}
 			$users = $DB->get_records('capquiz_user', ['capquiz_id' => $qlist->capquiz_id]);
 			foreach ($users as &$user) {
 				// Create new question usage for user.

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -260,8 +260,14 @@ function xmldb_capquiz_upgrade($oldversion) {
 				$DB->update_record('capquiz_user', $user);
 				$attempts = $DB->get_records('question_attempts', ['questionusageid' => $oldqubaid]);
 				foreach ($attempts as &$attempt) {
-					$attempt->questionusageid = $user->question_usage_id;
-					$DB->update_record('question_attempts', $attempt);
+					$steps = $DB->get_records('question_attempt_steps', [
+						'questionattemptid' => $attempt->id,
+						'userid' => $user->user_id
+					]);
+					if (count($steps) > 0) {
+						$attempt->questionusageid = $newqubaid;
+						$DB->update_record('question_attempts', $attempt);
+					}
 				}
 			}
 

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -224,7 +224,7 @@ function xmldb_capquiz_upgrade($oldversion) {
 		
 		// Define field id to be added to capquiz_user.
 		$table = new xmldb_table('capquiz_user');
-		$field = new xmldb_field('question_usage_id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null, null);
+		$field = new xmldb_field('question_usage_id', XMLDB_TYPE_INTEGER, '10', null, null, XMLDB_SEQUENCE, null, null);
 		
 		// Conditionally launch add field id.
 		if (!$dbman->field_exists($table, $field)) {
@@ -245,7 +245,7 @@ function xmldb_capquiz_upgrade($oldversion) {
 			if (!$oldqubaid) {
 				continue;
 			}
-			$oldquba = $DB->get_record('question_usage', ['id' => $oldqubaid]);
+			$oldquba = $DB->get_record('question_usages', ['id' => $oldqubaid]);
 			$users = $DB->get_records('capquiz_user', ['question_usage_id' => $oldqubaid]);
 			foreach ($users as &$user) {
 				// Create new question usage for user.

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -220,5 +220,42 @@ function xmldb_capquiz_upgrade($oldversion) {
         // Capquiz savepoint reached.
         upgrade_mod_savepoint(true, 2020091600, 'capquiz');
     }
+	if ($oldversion < 2021020600) {
+
+        // Define key question_usage_id (foreign-unique) to be dropped from capquiz_question_list.
+        $table = new xmldb_table('capquiz_question_list');
+        $key = new xmldb_key('question_usage_id', XMLDB_KEY_FOREIGN_UNIQUE, ['question_usage_id'], 'question_usages', ['id']);
+
+        // Launch drop key question_usage_id.
+        $dbman->drop_key($table, $key);
+
+        // Define field question_usage_id to be dropped from capquiz_question_list.
+        $table = new xmldb_table('capquiz_question_list');
+        $field = new xmldb_field('question_usage_id');
+
+        // Conditionally launch drop field question_usage_id.
+        if ($dbman->field_exists($table, $field)) {
+            $dbman->drop_field($table, $field);
+        }
+
+		// Define field id to be added to capquiz_user.
+		$table = new xmldb_table('capquiz_user');
+		$field = new xmldb_field('question_usage_id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null, null);
+		
+		// Conditionally launch add field id.
+		if (!$dbman->field_exists($table, $field)) {
+			$dbman->add_field($table, $field);
+		}
+
+		// Define key question_usage_id (foreign-unique) to be added to capquiz_user.
+		$table = new xmldb_table('capquiz_user');
+		$key = new xmldb_key('question_usage_id', XMLDB_KEY_FOREIGN_UNIQUE, ['question_usage_id'], 'question_usages', ['id']);
+		
+		// Launch add key question_usage_id.
+		$dbman->add_key($table, $key);
+
+        // Capquiz savepoint reached.
+        upgrade_mod_savepoint(true, 2021020600, 'capquiz');
+    }
     return true;
 }

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -224,7 +224,7 @@ function xmldb_capquiz_upgrade($oldversion) {
 		
 		// Define field id to be added to capquiz_user.
 		$table = new xmldb_table('capquiz_user');
-		$field = new xmldb_field('question_usage_id', XMLDB_TYPE_INTEGER, '10', null, null, XMLDB_SEQUENCE, null, null);
+		$field = new xmldb_field('question_usage_id', XMLDB_TYPE_INTEGER, '10', null, null, null, null, null);
 		
 		// Conditionally launch add field id.
 		if (!$dbman->field_exists($table, $field)) {
@@ -246,7 +246,7 @@ function xmldb_capquiz_upgrade($oldversion) {
 				continue;
 			}
 			$oldquba = $DB->get_record('question_usages', ['id' => $oldqubaid]);
-			$users = $DB->get_records('capquiz_user', ['question_usage_id' => $oldqubaid]);
+			$users = $DB->get_records('capquiz_user', ['capquiz_id' => $qlist->capquiz_id]);
 			foreach ($users as &$user) {
 				// Create new question usage for user.
 				$newquba = new stdClass();

--- a/lib.php
+++ b/lib.php
@@ -47,8 +47,11 @@ function capquiz_update_instance(stdClass $capquiz) {
 function capquiz_delete_instance(int $cmid) {
     $capquiz = new capquiz($cmid);
     if ($capquiz) {
-        $quba = $capquiz->question_usage();
-        \question_engine::delete_questions_usage_by_activity($quba->get_id());
+        $user = $capquiz->user();
+        if ($user) {
+            $quba = $user->question_usage();
+            \question_engine::delete_questions_usage_by_activity($quba->get_id());
+        }
     }
 }
 

--- a/lib.php
+++ b/lib.php
@@ -33,8 +33,6 @@ function capquiz_add_instance(stdClass $modformdata) {
     $modformdata->time_modified = time();
     $modformdata->time_created = time();
     $modformdata->published = false;
-    $modformdata->question_list_id = null;
-    $modformdata->question_usage_id = null;
     return $DB->insert_record('capquiz', $modformdata);
 }
 
@@ -66,18 +64,15 @@ function capquiz_reset_userdata($data) {
 
     $instances = $DB->get_records('capquiz', ['course' => $data->courseid]);
     foreach ($instances as $instance) {
-        $qlist = $DB->get_record('capquiz_question_list', ['capquiz_id' => $instance->id]);
-        if (!$qlist) {
+        $users = $DB->get_records('capquiz_user', ['capquiz_id' => $instance->id]);
+        if (!$users) {
             continue;
         }
-        \question_engine::delete_questions_usage_by_activity($qlist->question_usage_id);
-        $users = $DB->get_records('capquiz_user', ['capquiz_id' => $instance->id]);
         foreach ($users as $user) {
+            \question_engine::delete_questions_usage_by_activity($user->question_usage_id);
             $DB->delete_records('capquiz_attempt', ['user_id' => $user->id]);
         }
         $DB->delete_records('capquiz_user', ['capquiz_id' => $instance->id]);
-        $qlist->question_usage_id = null;
-        $DB->update_record('capquiz_question_list', $qlist);
     }
     $status[] = ['component' => $strmodname, 'item' => $strdeleteattempts, 'error' => false];
     return $status;

--- a/report/attemptsreport_table.php
+++ b/report/attemptsreport_table.php
@@ -80,7 +80,7 @@ abstract class capquiz_attempts_report_table extends table_sql {
     /** @var sql_join Contains joins, wheres, params to find the students in the course. */
     protected $studentsjoins;
 
-    /** @var object the questions that comprise this capquiz.. */
+    /** @var array the questions that comprise this capquiz.. */
     protected $questions;
 
     /** @var bool whether to include the column with checkboxes to select each attempt. */
@@ -479,7 +479,7 @@ abstract class capquiz_attempts_report_table extends table_sql {
 
         $dm = new question_engine_data_mapper();
         $latesstepdata = $dm->load_questions_usages_latest_steps(
-            $qubaids, array_keys($this->questions));
+            $qubaids, array_map(function($o) { return $o->slot; }, $this->questions));
 
         $lateststeps = array();
         foreach ($latesstepdata as $step) {
@@ -505,7 +505,6 @@ abstract class capquiz_attempts_report_table extends table_sql {
                 $qubaids[] = $attempt->usageid;
             }
         }
-
         return new qubaid_list($qubaids);
     }
 

--- a/report/attemptsreport_table.php
+++ b/report/attemptsreport_table.php
@@ -352,7 +352,7 @@ abstract class capquiz_attempts_report_table extends table_sql {
                 'imagealt', 'institution', 'department', 'email'));
         $allnames = get_all_user_name_fields(true, 'u');
         $fields .= '
-                cql.question_usage_id AS usageid,
+                cu.question_usage_id AS usageid,
                 ca.id AS attempt,
                 u.id AS userid,
                 u.idnumber, ' . $allnames . ',
@@ -372,7 +372,7 @@ abstract class capquiz_attempts_report_table extends table_sql {
                         ON cql.capquiz_id = :capquizid
                         AND cql.is_template = 0";
 
-        $from .= "\nJOIN {question_usages} qu ON qu.id = cql.question_usage_id";
+        $from .= "\nJOIN {question_usages} qu ON qu.id = cu.question_usage_id";
         $from .= "\nJOIN {question_attempts} qa ON qa.questionusageid = qu.id";
 
         $from .= "\nJOIN {capquiz_attempt} ca ON ca.user_id = cu.id AND ca.slot = qa.slot";

--- a/report/reportlib.php
+++ b/report/reportlib.php
@@ -93,26 +93,24 @@ function capquiz_has_questions($capquizid) {
  */
 function capquiz_report_get_questions(capquiz $capquiz) {
     global $DB;
-    $qsbyslot = $DB->get_records_sql("
-            SELECT DISTINCT
-                   ca.slot,
-                   q.id,
-                   q.qtype,
-                   q.length
+    $sql = 'SELECT DISTINCT ' . $DB->sql_concat('qa.id',"'#'",'cu.id', 'ca.slot') . ' AS uniqueid,
+                ca.slot,
+                q.id,
+                q.qtype,
+                q.length
+            FROM {question} q
+            JOIN {capquiz_question} cq ON cq.question_id = q.id
+            JOIN {capquiz_question_list} cql ON cql.id = cq.question_list_id AND cql.is_template = 0
+            JOIN {capquiz_user} cu ON cu.capquiz_id = cql.capquiz_id
+            JOIN {question_usages} qu ON qu.id = cu.question_usage_id
+            JOIN {question_attempts} qa ON qa.questionusageid = qu.id
+            JOIN {capquiz_attempt} ca ON ca.question_id = cq.id AND ca.slot = qa.slot AND ca.user_id = cu.id
 
-              FROM {question} q
-              JOIN {capquiz_question} cq ON cq.question_id = q.id
-              JOIN {capquiz_question_list} cql ON cql.id = cq.question_list_id AND cql.is_template = 0
-              JOIN {capquiz_user} cu ON cu.id = cql.capquiz_id
-              JOIN {question_usages} qu ON qu.id = cu.question_usage_id
-              JOIN {question_attempts} qa ON qa.questionusageid = qu.id
-              JOIN {capquiz_attempt} ca ON ca.question_id = cq.id AND ca.slot = qa.slot
+            WHERE cu.capquiz_id = ?
+            AND q.length > 0
 
-              WHERE cql.capquiz_id = ?
-               AND q.length > 0
-
-              ORDER BY ca.slot", array($capquiz->id()));
-
+            ORDER BY ca.slot';
+    $qsbyslot = $DB->get_records_sql($sql, array($capquiz->id()));
     $number = 1;
     foreach ($qsbyslot as $question) {
         $question->number = $number;
@@ -149,13 +147,12 @@ function capquiz_num_attempt_summary(capquiz $capquiz, $returnzero = false) {
  */
 function capquiz_report_num_attempt(capquiz $capquiz): int {
     global $DB;
-    $sql = 'SELECT COUNT(ca.id)
+    $sql = 'SELECT  COUNT( ca.id)
               FROM {capquiz_attempt} ca
-              JOIN {capquiz_question_list} cql ON cql.capquiz_id = :capquizid AND cql.is_template = 0
-              JOIN {capquiz_user} cu ON cu.id = cql.capquiz_id
+              JOIN {capquiz_user} cu ON cu.capquiz_id = :capquizid AND cu.id = ca.user_id
               JOIN {question_usages} qu ON qu.id = cu.question_usage_id
               JOIN {question_attempts} qa ON qa.questionusageid = qu.id AND qa.slot = ca.slot
-              JOIN {capquiz_question} cq ON cq.question_list_id = cql.id AND cq.id = ca.question_id';
+              JOIN {capquiz_question} cq ON cq.id = ca.question_id';
     $attempts = $DB->count_records_sql($sql, ['capquizid' => $capquiz->id()]);
     return $attempts;
 }

--- a/report/reportlib.php
+++ b/report/reportlib.php
@@ -103,14 +103,15 @@ function capquiz_report_get_questions(capquiz $capquiz) {
               FROM {question} q
               JOIN {capquiz_question} cq ON cq.question_id = q.id
               JOIN {capquiz_question_list} cql ON cql.id = cq.question_list_id AND cql.is_template = 0
-              JOIN {question_usages} qu ON qu.id = cql.question_usage_id
+              JOIN {capquiz_user} cu ON cu.id = cql.capquiz_id
+              JOIN {question_usages} qu ON qu.id = cu.question_usage_id
               JOIN {question_attempts} qa ON qa.questionusageid = qu.id
               JOIN {capquiz_attempt} ca ON ca.question_id = cq.id AND ca.slot = qa.slot
 
-             WHERE cql.capquiz_id = ?
+              WHERE cql.capquiz_id = ?
                AND q.length > 0
 
-          ORDER BY ca.slot", array($capquiz->id()));
+              ORDER BY ca.slot", array($capquiz->id()));
 
     $number = 1;
     foreach ($qsbyslot as $question) {
@@ -151,7 +152,8 @@ function capquiz_report_num_attempt(capquiz $capquiz): int {
     $sql = 'SELECT COUNT(ca.id)
               FROM {capquiz_attempt} ca
               JOIN {capquiz_question_list} cql ON cql.capquiz_id = :capquizid AND cql.is_template = 0
-              JOIN {question_usages} qu ON qu.id = cql.question_usage_id
+              JOIN {capquiz_user} cu ON cu.id = cql.capquiz_id
+              JOIN {question_usages} qu ON qu.id = cu.question_usage_id
               JOIN {question_attempts} qa ON qa.questionusageid = qu.id AND qa.slot = ca.slot
               JOIN {capquiz_question} cq ON cq.question_list_id = cql.id AND cq.id = ca.question_id';
     $attempts = $DB->count_records_sql($sql, ['capquizid' => $capquiz->id()]);

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2021020600;
+$plugin->version = 2021020601;
 $plugin->requires = 2016120500;
 $plugin->cron = 0;
 $plugin->component = 'mod_capquiz';

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2021020900;
+$plugin->version = 2021020903;
 $plugin->requires = 2016120500;
 $plugin->cron = 0;
 $plugin->component = 'mod_capquiz';

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2021020601;
+$plugin->version = 2021020900;
 $plugin->requires = 2016120500;
 $plugin->cron = 0;
 $plugin->component = 'mod_capquiz';

--- a/version.php
+++ b/version.php
@@ -25,9 +25,9 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2020091600;
+$plugin->version = 2021020600;
 $plugin->requires = 2016120500;
 $plugin->cron = 0;
 $plugin->component = 'mod_capquiz';
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = '0.5.0';
+$plugin->release = '0.6.0';

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2021020903;
+$plugin->version = 2021021000;
 $plugin->requires = 2016120500;
 $plugin->cron = 0;
 $plugin->component = 'mod_capquiz';

--- a/view.php
+++ b/view.php
@@ -48,7 +48,7 @@ if (has_capability('mod/capquiz:instructor', $capquiz->context())) {
 } else {
     require_capability('mod/capquiz:student', $capquiz->context());
     // Question engine is null if the quiz is not published.
-    $qengine = $capquiz->question_engine();
+    $qengine = $capquiz->question_engine($capquiz->user());
     if ($qengine) {
         $qengine->delete_invalid_attempt($capquiz->user());
     }


### PR DESCRIPTION
Question usages are now stored per user, instead of question lists.

The upgrade script will split the question usage into one for each user, then delete the original.