### PR TITLE
Implement new delete_instance callback.

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -32,3 +32,20 @@
  */
 class capquiz_exception extends moodle_exception {
 }
+
+/**
+ * A {@link qubaid_condition} for finding all the question usages belonging to
+ * a particular capquiz.
+ *
+ * @author      sumaiya Javed <sumaiya.javed@catalyst.net.nz>
+ * @copyright   2023 Catalyst IT Ltd
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class qubaids_for_capquiz extends qubaid_join {
+    public function __construct($capquizid) {
+        $where = 'capquiza.capquiz_id = :quizaquiz';
+        $params = array('quizaquiz' => $capquizid);
+
+        parent::__construct('{capquiz_user} capquiza', 'capquiza.question_usage_id', $where, $params);
+    }
+}


### PR DESCRIPTION
Hi,

Currently a capquiz activity cannot be deleted. It gets deleted and then goes to the recycle bin. See details here in the report issue #206 

Testing instructions
- Create a new capquiz activity with questions and publish it
- Delete the activity and run cron. You will see the below error stack
```
Adhoc task failed: core_course\task\course_delete_modules,Coding error detected, it must be fixed by a programmer: The course module 6 could not be deleted. Can't find data record in database. (SELECT cm.*, m.name, md.name AS modname 
              FROM {course_modules} cm
                   JOIN {modules} md ON md.id = cm.module
                   JOIN {capquiz} m ON m.id = cm.instance
                   
             WHERE cm.id = :cmid AND md.name = :modulename
                   
[array (
  'cmid' => 3,
  'modulename' => 'capquiz',
)]): /var/www/html/lib/dml/moodle_database.php(1682) #0 /var/www/html/lib/datalib.php(1266): moodle_database->get_record_sql('SELECT cm.*, m....', Array, 2)
#1 /var/www/html/mod/capquiz/classes/capquiz.php(75): get_coursemodule_from_id('capquiz', 1, 0, false, 2)
#2 /var/www/html/mod/capquiz/lib.php(67): mod_capquiz\capquiz->__construct(1)
#3 /var/www/html/course/lib.php(907): capquiz_delete_instance(1)
#4 /var/www/html/course/classes/task/course_delete_modules.php(66): course_delete_module('6')
#5 /var/www/html/lib/cronlib.php(367): core_course\task\course_delete_modules->execute()
#6 /var/www/html/lib/cronlib.php(198): cron_run_inner_adhoc_task(Object(core_course\task\course_delete_modules))
#7 /var/www/html/lib/cronlib.php(76): cron_run_adhoc_tasks(1706240953)
#8 /var/www/html/admin/cli/cron.php(178): cron_run()
```

Regards,
Sumaiya
